### PR TITLE
Enable CNAME destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 This module creates:
 
-- A Record that points `subdomain.cloudflare_zone_domain` to the destination IP
-- A Record that points `*.subdomain.cloudflare_zone_domain` to the destination IP
+- A/CNAME Record that points `subdomain.cloudflare_zone_domain` to the destination
+- A/CNAME Record that points `*.subdomain.cloudflare_zone_domain` to the destination
 - An Edge Certificate for `subdomain.cloudflare_zone_domain`, `*.subdomain.cloudflare_zone_domain`
 - An Origin Certificate for `subdomain.cloudflare_zone_domain`, `*.subdomain.cloudflare_zone_domain`
 ## Usage
@@ -15,7 +15,7 @@ This module creates:
 module "cloudflare-records" {
   source                 = "github.com/dapperlabs-platform/terraform-cloudflare-records?ref=tag"
   cloudflare_zone_domain = "zone.com"
-  destination_ip         = "1.2.3.4"
-  subdomain     = "app.zone.com"
+  destination            = "1.2.3.4"
+  subdomain              = "app.zone.com"
 }
 ```

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
-variable "destination_ip" {
-  description = "Your destination IP (Load balancer)"
+variable "destination" {
+  description = "Your destination IP for A or subdomain for CNAME records"
   type        = string
 }
 


### PR DESCRIPTION
Renames `destination_ip` to `destination` to work with `A` and `CNAME` records
Uses regex to determine whether the destination is an IP address
