### PR TITLE
Add  `wait_for_active_status` and lifecycle to cert packs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,10 +53,15 @@ resource "cloudflare_certificate_pack" "internal_domain_cert_pack" {
     "${var.cloudflare_zone_domain}",
     "${local.wildcard}.${var.cloudflare_zone_domain}"
   ]
-  validation_method     = local.validation_methods[var.certificate_pack_certificate_authority]
-  validity_days         = 365
-  certificate_authority = var.certificate_pack_certificate_authority
-  cloudflare_branding   = false
+  validation_method      = local.validation_methods[var.certificate_pack_certificate_authority]
+  validity_days          = 365
+  certificate_authority  = var.certificate_pack_certificate_authority
+  cloudflare_branding    = false
+  wait_for_active_status = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Create a CSR and generate a CA certificate


### PR DESCRIPTION
Following the provider's recommendation,
>Important:
Certificate packs are not able to be updated in place and if you require a zero downtime rotation, you need to use Terraform's meta-arguments for [lifecycle](https://www.terraform.io/docs/configuration/resources.html#lifecycle-lifecycle-customizations) blocks. create_before_destroy should be suffice for most scenarios (exceptions are things like missing entitlements, high ranking domain). To completely de-risk rotations, use you can create multiple resources using a 2-phase change where you have both resources live at once and you remove the old one once you've confirmed the certificate is available.

https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/certificate_pack