### PR TITLE
Add default street address to prevent self destruct

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,7 @@ resource "tls_cert_request" "cert_request" {
   subject {
     common_name  = ""
     organization = "ORG"
+    street_address = []
   }
 }
 


### PR DESCRIPTION
We're seeing cases the the default `street_address` value of `null` forces a replacement of a perfectly good resource.  This attempts to mitigate that with an explicit default.