### PR TITLE
Remove the . after a wildcard with no subdomain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 locals {
-  wildcard = var.subdomain != "*" ? "*.${var.subdomain}" : "*."
+  wildcard = var.subdomain != "*" ? "*.${var.subdomain}" : var.subdomain
   # result is IP string if var.destination is an IP address, null otherwise 
   regex_result = try(regex("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$", var.destination), null)
   # destination is an IP address if regex_result is not null.


### PR DESCRIPTION
If no subdomain is passed in, then the current version appends a `.` to the wildcard, which certainly makes certificate generation go wild.  This removes the offending character and restores balance.