### PR TITLE
Update certificate pack certificate authority providers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,12 +9,12 @@ terraform {
 
 locals {
   wildcard = var.subdomain != "*" ? "*.${var.subdomain}" : var.subdomain
-  # result is IP string if var.destination is an IP address, null otherwise 
+  # result is IP string if var.destination is an IP address, null otherwise
   regex_result = try(regex("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$", var.destination), null)
   # destination is an IP address if regex_result is not null.
   is_a_record = local.regex_result != null
   validation_methods = {
-    "digicert"     = "txt"
+    "google"       = "txt"
     "lets_encrypt" = "http"
   }
 }
@@ -54,7 +54,7 @@ resource "cloudflare_certificate_pack" "internal_domain_cert_pack" {
     "${local.wildcard}.${var.cloudflare_zone_domain}"
   ]
   validation_method      = local.validation_methods[var.certificate_pack_certificate_authority]
-  validity_days          = 365
+  validity_days          = 90
   certificate_authority  = var.certificate_pack_certificate_authority
   cloudflare_branding    = false
   wait_for_active_status = true

--- a/variables.tf
+++ b/variables.tf
@@ -16,9 +16,9 @@ variable "subdomain" {
 variable "certificate_pack_certificate_authority" {
   description = "Certificate authority for the advanced certificate pack. Allowed values are digicert and lets_encrypt"
   type        = string
-  default     = "digicert"
+  default     = "google"
   validation {
-    condition     = contains(["digicert", "lets_encrypt"], var.certificate_pack_certificate_authority)
-    error_message = "The certificate_pack_certificate_authority value must be digicert or lets_encrypt."
+    condition     = contains(["google", "lets_encrypt"], var.certificate_pack_certificate_authority)
+    error_message = "The certificate_pack_certificate_authority value must be google or lets_encrypt."
   }
 }


### PR DESCRIPTION
Cloudflare apparently no longer supports digicert, so that has been removed and google is added. The default is now set to lets_encrypt