### PR TITLE
Prevent thrashing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,9 @@ locals {
   }
 }
 
+data "cloudflare_zone" "zone" {
+  zone_id = var.cloudflare_zone_id
+}
 
 resource "cloudflare_record" "subdomain_a_record" {
   zone_id = var.cloudflare_zone_id
@@ -44,8 +47,8 @@ resource "cloudflare_certificate_pack" "internal_domain_cert_pack" {
   zone_id = var.cloudflare_zone_id
   type    = "advanced"
   hosts = concat([
-    "${var.cloudflare_zone_domain}",
-    "${local.wildcard}.${var.cloudflare_zone_domain}"
+    "${data.cloudflare_zone.zone.name}",
+    "${local.wildcard}.${data.cloudflare_zone.zone.name}"
   ], var.additional_hosts)
   validation_method      = local.validation_methods[var.certificate_pack_certificate_authority]
   validity_days          = 90

--- a/main.tf
+++ b/main.tf
@@ -19,10 +19,6 @@ locals {
   }
 }
 
-data "cloudflare_zone" "zone" {
-  zone_id = var.cloudflare_zone_id
-}
-
 resource "cloudflare_record" "subdomain_a_record" {
   zone_id = var.cloudflare_zone_id
   type    = local.is_a_record ? "A" : "CNAME"
@@ -47,8 +43,8 @@ resource "cloudflare_certificate_pack" "internal_domain_cert_pack" {
   zone_id = var.cloudflare_zone_id
   type    = "advanced"
   hosts = concat([
-    "${data.cloudflare_zone.zone.name}",
-    "${local.wildcard}.${data.cloudflare_zone.zone.name}"
+    "${var.cloudflare_zone_domain}",
+    "${local.wildcard}.${var.cloudflare_zone_domain}"
   ], var.additional_hosts)
   validation_method      = local.validation_methods[var.certificate_pack_certificate_authority]
   validity_days          = 90

--- a/main.tf
+++ b/main.tf
@@ -43,10 +43,10 @@ resource "cloudflare_record" "wildcard_subdomain_a_record" {
 resource "cloudflare_certificate_pack" "internal_domain_cert_pack" {
   zone_id = var.cloudflare_zone_id
   type    = "advanced"
-  hosts = [
+  hosts = concat([
     "${var.cloudflare_zone_domain}",
     "${local.wildcard}.${var.cloudflare_zone_domain}"
-  ]
+  ], var.additional_hosts)
   validation_method      = local.validation_methods[var.certificate_pack_certificate_authority]
   validity_days          = 90
   certificate_authority  = var.certificate_pack_certificate_authority

--- a/main.tf
+++ b/main.tf
@@ -19,15 +19,9 @@ locals {
   }
 }
 
-# cloudflare zone for internalSubdomain
-data "cloudflare_zones" "zone" {
-  filter {
-    name = var.cloudflare_zone_domain
-  }
-}
 
 resource "cloudflare_record" "subdomain_a_record" {
-  zone_id = lookup(data.cloudflare_zones.zone.zones[0], "id")
+  zone_id = var.cloudflare_zone_id
   type    = local.is_a_record ? "A" : "CNAME"
   ttl     = 1
   name    = var.subdomain
@@ -37,7 +31,7 @@ resource "cloudflare_record" "subdomain_a_record" {
 
 resource "cloudflare_record" "wildcard_subdomain_a_record" {
   count   = var.subdomain != "*" ? 1 : 0
-  zone_id = lookup(data.cloudflare_zones.zone.zones[0], "id")
+  zone_id = var.cloudflare_zone_id
   type    = local.is_a_record ? "A" : "CNAME"
   ttl     = 1
   name    = local.wildcard
@@ -47,7 +41,7 @@ resource "cloudflare_record" "wildcard_subdomain_a_record" {
 
 #  Edge Certificate for vanityDomain
 resource "cloudflare_certificate_pack" "internal_domain_cert_pack" {
-  zone_id = lookup(data.cloudflare_zones.zone.zones[0], "id")
+  zone_id = var.cloudflare_zone_id
   type    = "advanced"
   hosts = [
     "${var.cloudflare_zone_domain}",

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,13 @@ variable "destination" {
   type        = string
 }
 
-variable "cloudflare_zone_id" {
+variable "cloudflare_zone_domain" {
   description = "Main cloudflare zone to create records and certificates in"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Main cloudflare zone id to create records and certificates in"
   type        = string
 }
 
@@ -22,4 +27,10 @@ variable "certificate_pack_certificate_authority" {
     condition     = contains(["google", "lets_encrypt", "ssl_com"], var.certificate_pack_certificate_authority)
     error_message = "The certificate_pack_certificate_authority value must be google or lets_encrypt."
   }
+}
+
+variable "additional_hosts" {
+  description = "Additional hosts to include in the certificate pack"
+  type        = list(string)
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,9 @@ variable "destination" {
   type        = string
 }
 
-variable "cloudflare_zone_domain" {
+variable "cloudflare_zone_id" {
   description = "Main cloudflare zone to create records and certificates in"
+  type        = string
 }
 
 variable "subdomain" {
@@ -18,7 +19,7 @@ variable "certificate_pack_certificate_authority" {
   type        = string
   default     = "google"
   validation {
-    condition     = contains(["google", "lets_encrypt"], var.certificate_pack_certificate_authority)
+    condition     = contains(["google", "lets_encrypt", "ssl_com"], var.certificate_pack_certificate_authority)
     error_message = "The certificate_pack_certificate_authority value must be google or lets_encrypt."
   }
 }


### PR DESCRIPTION
With Cloudflare Terraform, there's no pretty way to do this.  Both the Zone ID and the Zone Domain fall in the critical path of evaluation at compile time, and if you don't have a static version of both when this gets evaluated, Terraform wants to start deleting and recreating stuff.  Let's stop the madness, even if it doesn't make sense.